### PR TITLE
Fix ACS crashing when there's no date

### DIFF
--- a/src/acs/src/tracker.py
+++ b/src/acs/src/tracker.py
@@ -208,13 +208,22 @@ class Tracker:
         package.found = True
 
         for status in response["statusHistory"]:
-            package.locations.append(
-                Location(
-                    datetime = parser.isoparse(status["controlPointDate"]).astimezone(tz=tz.gettz("Europe/Athens")),
-                    location = status["controlPoint"],
-                    description = status["description"],
+            try:
+                package.locations.append(
+                    Location(
+                        datetime = parser.isoparse(status["controlPointDate"]).astimezone(tz=tz.gettz("Europe/Athens")),
+                        location = status["controlPoint"],
+                        description = status["description"],
+                    )
                 )
-            )
+            except KeyError:
+                package.locations.append(
+                    Location(
+                        datetime = datetime.datetime.now(),
+                        location = status["controlPoint"],
+                        description = status["description"],
+                    )
+                )
 
         package.delivered = response["isDelivered"]
 
@@ -269,13 +278,22 @@ class Tracker:
 
             locations = []
             for status in package["statusHistory"]:
-                locations.append(
-                    Location(
-                        datetime = parser.isoparse(status["controlPointDate"]).astimezone(tz=tz.gettz("Europe/Athens")),
-                        location = status["controlPoint"],
-                        description = status["description"],
+                try:
+                    package.locations.append(
+                        Location(
+                            datetime = parser.isoparse(status["controlPointDate"]).astimezone(tz=tz.gettz("Europe/Athens")),
+                            location = status["controlPoint"],
+                            description = status["description"],
+                        )
                     )
-                )
+                except KeyError:
+                    package.locations.append(
+                        Location(
+                            datetime = datetime.datetime.now(),
+                            location = status["controlPoint"],
+                            description = status["description"],
+                        )
+                    )
 
             p = Package()
             p.found = True


### PR DESCRIPTION
If controlPointDate was missing the server would crash and return 500. Now it will just return the current date